### PR TITLE
Allow pushing only a tag if no release branch is provided

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -83,6 +83,10 @@ inputs:
     description: "Next development version"
     required: false
     default: ""
+  traceEnabled:
+    description: "Enable tracing executing of scripts"
+    required: false
+    default: "false"
 
 outputs:
   prepared:
@@ -134,6 +138,7 @@ runs:
         MAVEN_RELEASE_TAG=${{ inputs.mavenReleaseTag }}
         MAVEN_RELEASE_VERSION=${{ inputs.mavenReleaseVersion }}
         MAVEN_NEXT_DEVELOPMENT_VERSION=${{ inputs.mavenNextDevelopmentVersion }}
+        TRACE_ENABLED=${{ inputs.traceEnabled }}
         EOF
     - name: "Set GIT automation credentials"
       run: git config --global user.name "${{ inputs.gitUserName }}" && git config --global user.email "${{ inputs.gitUserEmail }}"

--- a/check.sh
+++ b/check.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
+
 set -euo pipefail
+[[ $TRACE_ENABLED == "true" ]] && set -x
+
 source ${GITHUB_ACTION_PATH}/common.sh
 
 # ------------------------------------------------------------------------------

--- a/common.sh
+++ b/common.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+[[ $TRACE_ENABLED == "true" ]] && set -x
+
 if [[ -f "${MAVEN_RELEASE_SETTINGS_XML}" ]]
 then
   # Use the provided Maven settings.xml

--- a/export_version.sh
+++ b/export_version.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
+
 set -euo pipefail
+[[ $TRACE_ENABLED == "true" ]] && set -x
+
 source ${GITHUB_ACTION_PATH}/common.sh
 
 if [[ "${MAVEN_RELEASE_VERSION}" != "" ]]; then

--- a/export_version.sh
+++ b/export_version.sh
@@ -2,10 +2,10 @@
 set -euo pipefail
 source ${GITHUB_ACTION_PATH}/common.sh
 
-version=$(mavenProjectVersion | sed 's/-SNAPSHOT//')
-
 if [[ "${MAVEN_RELEASE_VERSION}" != "" ]]; then
   version="${MAVEN_RELEASE_VERSION}"
+else
+  version=$(mavenProjectVersion | sed 's/-SNAPSHOT//')
 fi
 
 set_output "version" "${version}"

--- a/perform.sh
+++ b/perform.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
+
 set -euo pipefail
+[[ $TRACE_ENABLED == "true" ]] && set -x
+
 source ${GITHUB_ACTION_PATH}/common.sh
 
 # ------------------------------------------------------------------------------

--- a/post.sh
+++ b/post.sh
@@ -11,9 +11,8 @@ then
   # Make the release Maven project version available to any scripts
   echo "Running release post actions for version ${MAVEN_PROJECT_VERSION}"
   echo "------------------------------------------------------------------------------"
-  for postReleaseScript in `ls ${RELEASE_POST_SCRIPTS}`
+  for script in "${RELEASE_POST_SCRIPTS}"/*
   do
-    script="${RELEASE_POST_SCRIPTS}/${postReleaseScript}"
     if [[ -x "${script}" ]]
     then
       echo "Running post action ${script}"

--- a/post.sh
+++ b/post.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
+
 set -euo pipefail
+[[ $TRACE_ENABLED == "true" ]] && set -x
+
 source ${GITHUB_ACTION_PATH}/common.sh
 
 echo "------------------------------------------------------------------------------"

--- a/pre.sh
+++ b/pre.sh
@@ -11,9 +11,8 @@ then
   # Make the release Maven project version available to any scripts
   echo "Running release pre actions for version ${MAVEN_PROJECT_VERSION}"
   echo "------------------------------------------------------------------------------"
-  for preReleaseScript in `ls ${RELEASE_PRE_SCRIPTS}`
+  for script in "${RELEASE_PRE_SCRIPTS}"/*
   do
-    script="${RELEASE_PRE_SCRIPTS}/${preReleaseScript}"
     if [[ -x "${script}" ]]
     then
       echo "Running pre action ${script}"

--- a/pre.sh
+++ b/pre.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
+
 set -euo pipefail
+[[ $TRACE_ENABLED == "true" ]] && set -x
+
 source ${GITHUB_ACTION_PATH}/common.sh
 
 echo "------------------------------------------------------------------------------"

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
+
 set -euo pipefail
+[[ $TRACE_ENABLED == "true" ]] && set -x
+
 source ${GITHUB_ACTION_PATH}/common.sh
 
 # ------------------------------------------------------------------------------

--- a/push.sh
+++ b/push.sh
@@ -2,6 +2,13 @@
 set -euo pipefail
 source ${GITHUB_ACTION_PATH}/common.sh
 
+function fail_with_msg() {
+  # $1 = message
+  echo "::error::${1}"
+  set_output "executed" "false"
+  exit 1
+}
+
 # ------------------------------------------------------------------------------
 # Push the release commits and tags
 # ------------------------------------------------------------------------------
@@ -11,15 +18,14 @@ then
   echo
   echo "Pushing release commits and tag"
   echo "------------------------------------------------------------------------------"
-  if ! (git push origin HEAD:refs/heads/${RELEASE_BRANCH_NAME} && git push origin ${MAVEN_PROJECT_VERSION}); then
-      echo "Failed to push release commits and tag"
-      set_output "executed" "false"
-      exit 1
+  if [[ -n ${RELEASE_BRANCH_NAME} ]]; then
+    git push origin HEAD:refs/heads/${RELEASE_BRANCH_NAME} || fail_with_msg "Failed to push release commit"
   fi
+  git push origin ${MAVEN_PROJECT_VERSION} || fail_with_msg "Failed to push release tag"
   set_output "executed" "true"
 else
   echo "Skipped pushing release commits and tag"
-  echo "Branch to be pushed: origin HEAD:refs/heads/${RELEASE_BRANCH_NAME}"
+  [[ -n ${RELEASE_BRANCH_NAME} ]] && echo "Branch to be pushed: origin HEAD:refs/heads/${RELEASE_BRANCH_NAME}"
   echo "Tag to be pushed: ${MAVEN_PROJECT_VERSION}"
   set_output "executed" "false"
 fi

--- a/push.sh
+++ b/push.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
+
 set -euo pipefail
+[[ $TRACE_ENABLED == "true" ]] && set -x
+
 source ${GITHUB_ACTION_PATH}/common.sh
 
 function fail_with_msg() {


### PR DESCRIPTION
I can drop https://github.com/starburstdata/maven-release-github-action/commit/9d0ae755039aadc16ab34456ec67fc79f6b28967 if required but I found it useful to see exactly what was going on.